### PR TITLE
Style stuff

### DIFF
--- a/notepad.py
+++ b/notepad.py
@@ -50,8 +50,8 @@ def reminder(msg):
 def handleCommand(message, command, uID):
     words = command.split()
     try:
-        f = open(str(uID) + filename, 'rb')
-        currNotepad = pickle.load(f)
+        with open(str(uID) + filename, 'rb') as f:
+            currNotepad = pickle.load(f)
     except:
         currNotepad = []
     if words[0] == 'remindme':
@@ -94,8 +94,8 @@ def handleCommand(message, command, uID):
         r.raise_for_status()
         message.room.send_message('Opened your notepad [here]({}).'.format(r.text))
         return
-    f = open(str(uID) + filename, 'wb')
-    pickle.dump(currNotepad, f)
+    with open(str(uID) + filename, 'wb') as f:
+        pickle.dump(currNotepad, f)
         
 def onMessage(message, client):
     if str(message.room.id) != roomID:

--- a/notepad.py
+++ b/notepad.py
@@ -32,8 +32,8 @@ helpmessage = indent(dedent("""\
 
 
 def _parseMessage(msg):
-    temp = msg.split()
-    return ' '.join(temp[1:])
+    _,*tail = msg.split()
+    return ' '.join(tail)
 
 def buildReport(notepad):
     ret = {'botName' : 'Notepad'}
@@ -48,20 +48,20 @@ def reminder(msg):
     msg.message.reply('Reminder for this message is due.')
 
 def handleCommand(message, command, uID):
-    words = command.split()
+    word,*rest = command.split()
     try:
         with open(str(uID) + filename, 'rb') as f:
             currNotepad = pickle.load(f)
     except:
         currNotepad = []
-    if words[0] == 'remindme':
-        if len(words) < 2:
+    if word == 'remindme':
+        if len(rest) < 1:
             message.room.send_message('Missing duration argument.')
             return
         try:
-            time = float(words[1])
+            time = float(rest[0])
         except:
-            message.room.send_message('Number expected as first argument, got {}.'.format(words[1]))
+            message.room.send_message('Number expected as first argument, got {}.'.format(rest[0]))
             return
         if not time > 0:
             message.room.send_message('Duration must be positive.')
@@ -70,22 +70,22 @@ def handleCommand(message, command, uID):
         t.start()
         message.room.send_message('I will remind you of this message in {} minutes.'.format(time))
         return
-    elif words[0] == 'add':
-        currNotepad.append(' '.join(words[1:]))
+    elif word == 'add':
+        currNotepad.append(' '.join(rest))
         message.room.send_message('Added message to your notepad.')
-    elif words[0] == 'rm':
+    elif word == 'rm':
         try:
-            which = int(words[1])
+            which = int(rest[0])
             if which > len(currNotepad):
                 message.room.send_message('Item does not exist.')
             del currNotepad[which - 1]
             message.room.send_message('Message deleted.')
         except:
             return
-    elif words[0] == 'rma':
+    elif word == 'rma':
         currNotepad = []
         message.room.send_message('All messages deleted.')
-    elif words[0] == 'show':
+    elif word == 'show':
         if not currNotepad:
             message.room.send_message('You have no saved messages.')
             return

--- a/notepad.py
+++ b/notepad.py
@@ -70,10 +70,10 @@ def handleCommand(message, command, uID):
         t.start()
         message.room.send_message('I will remind you of this message in {} minutes.'.format(time))
         return
-    if words[0] == 'add':
+    elif words[0] == 'add':
         currNotepad.append(' '.join(words[1:]))
         message.room.send_message('Added message to your notepad.')
-    if words[0] == 'rm':
+    elif words[0] == 'rm':
         try:
             which = int(words[1])
             if which > len(currNotepad):
@@ -82,10 +82,10 @@ def handleCommand(message, command, uID):
             message.room.send_message('Message deleted.')
         except:
             return
-    if words[0] == 'rma':
+    elif words[0] == 'rma':
         currNotepad = []
         message.room.send_message('All messages deleted.')
-    if words[0] == 'show':
+    elif words[0] == 'show':
         if not currNotepad:
             message.room.send_message('You have no saved messages.')
             return
@@ -114,18 +114,18 @@ def onMessage(message, client):
         icommand = command.lower()
         if icommand == 'reboot notepad':
             os._exit(1)
-        if icommand == 'update notepad':
+        elif icommand == 'update notepad':
             call(['git', 'pull'])
             os._exit(1)
-        if icommand == 'help':
+        elif icommand == 'help':
             message.room.send_message('Try `commands <botname>`, e.g. `commands notepad`.')
-        if icommand in ['a', 'alive']:
+        elif icommand in ['a', 'alive']:
             message.room.send_message('[notepad] Yes.')
             return
-        if icommand == 'commands':
+        elif icommand == 'commands':
             message.room.send_message('[notepad] Try `commands notepad`')
             return
-        if icommand == 'commands notepad':
+        elif icommand == 'commands notepad':
             message.room.send_message(helpmessage)
             return
     except:

--- a/notepad.py
+++ b/notepad.py
@@ -61,14 +61,14 @@ def handleCommand(message, command, uID):
         try:
             time = float(words[1])
         except:
-            message.room.send_message('Number expected as first argument, got %s.'%words[1])
+            message.room.send_message('Number expected as first argument, got {}.'.format(words[1]))
             return
         if not time > 0:
             message.room.send_message('Duration must be positive.')
             return
         t = Timer(60*time, reminder, args=(message,))
         t.start()
-        message.room.send_message('I will remind you of this message in %s minutes.'%time)
+        message.room.send_message('I will remind you of this message in {} minutes.'.format(time))
         return
     if words[0] == 'add':
         currNotepad.append(' '.join(words[1:]))
@@ -92,7 +92,7 @@ def handleCommand(message, command, uID):
         report = buildReport(currNotepad)
         r = requests.post(apiUrl, data=js.dumps(report))
         r.raise_for_status()
-        message.room.send_message('Opened your notepad [here](%s).'%r.text)
+        message.room.send_message('Opened your notepad [here]({}).'.format(r.text))
         return
     f = open(str(uID) + filename, 'wb')
     pickle.dump(currNotepad, f)
@@ -134,7 +134,7 @@ def onMessage(message, client):
     try:
         handleCommand(message, command, userID)
     except Exception as e:
-        message.room.send_message('Error occurred: ' + str(e) + ' (cc @Baum)')
+        message.room.send_message('Error occurred: {} (cc @Baum)'.format(e))
 
 
 if 'ChatExchangeU' in os.environ:

--- a/notepad.py
+++ b/notepad.py
@@ -10,6 +10,7 @@ import requests
 import json as js
 from subprocess import call
 from threading import Timer
+from textwrap import dedent,indent
 
 import chatexchange.client
 import chatexchange.events
@@ -20,13 +21,15 @@ selfID = 7829893
 filename = ',notepad'
 apiUrl = 'http://reports.socvr.org/api/create-report'
 
-helpmessage = \
-        '    add `message`:        Add `message` to your notepad\n' + \
-        '    rm  `idx`:            Delete the message at `idx`\n' + \
-        '    rma:                  Clear your notepad\n' + \
-        '    show:                 Show your messages\n' + \
-        '    remindme `m` [...]:   Reminds you of this message in `m` minutes\n' + \
-        '    reboot notepad:       Reboot this bot'
+helpmessage = indent(dedent("""\
+                            add `message`:        Add `message` to your notepad
+                            rm  `idx`:            Delete the message at `idx`
+                            rma:                  Clear your notepad
+                            show:                 Show your messages
+                            remindme `m` [...]:   Reminds you of this message in `m` minutes
+                            reboot notepad:       Reboot this bot
+                            """), ' '*4)
+
 
 def _parseMessage(msg):
     temp = msg.split()


### PR DESCRIPTION
A bunch of minor mostly-style changes organized in several commits for ease of cherry-picking.
1. Use a triple-quoted string for the help message. On the one hand this should be more idiomatic, on the other hand this needs a combination of `textwrap.dedent` and `.indent` to keep it pretty, and the latter is missing in python 2. Also, the change adds a newline at the end of the help string, but the chat engine should ignore that.
2. Use format strings where possible (TODO: f-strings once 3.6 is the new norm ;)
3. Use context managers for the data files.
4. Add explicit `elif`s to chained mutually exclusive `if`s. Some of these are extra redundant because there are `return` statements interspersed, it's a matter of personal taste whether explicit `elif`s aid readability.
5. Use advanced iterable unpacking to make `head|rest` and `garbage|tail` kind of list separations a bit more convenient.