### PR TITLE
Allow multiple formats for time.

### DIFF
--- a/notepad.py
+++ b/notepad.py
@@ -8,6 +8,7 @@ import os
 import pickle
 import requests
 import json as js
+import re
 from subprocess import call
 from threading import Timer
 
@@ -57,9 +58,22 @@ def handleCommand(message, command, uID):
             message.room.send_message('Missing duration argument.')
             return
         try:
-            time = float(words[1])
+            m = re.match('^(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m?)?$', words[1])
+            if m is None:
+                message.room.send_message('Invalid format for time, got %s.'%words[1])
+                return
+            
+            time = 0
+            if m.group(1) is not None:
+                time += float(m.group(1)) * 1440
+            
+            if m.group(2) is not None:
+                time += float(m.group(2)) * 60
+
+            if m.group(3) is not None:
+                time += float(m.group(3))
         except:
-            message.room.send_message('Number expected as first argument, got %s.'%words[1])
+            message.room.send_message('Invalid format for time, got %s.'%words[1])
             return
         if not time > 0:
             message.room.send_message('Duration must be positive.')


### PR DESCRIPTION
This PR adds the ability to have multiple datetime formats for notepad. This greatly improves the current functionality by allowing users to specify datetimes in different formats. This closes #3.

Acceptable time formats now:
2d => 2880 minutes
2d5m => 2885 minutes
2d1h5m => 2945 minutes
2h => 120 minutes
30 => 30 minutes

This remains completely backwards compatible, allowing users to not specify any time parameter (`d`, `h`, `m`) and defaulting to minutes.

Word of note: This is my literal first python PR. Feel free to improve/comment. I did test and make sure this was working correctly, and you can see the results in the chatroom here: https://chat.stackoverflow.com/rooms/177119/notepaddev-test